### PR TITLE
Xmove support and vm cleanup

### DIFF
--- a/auxiliary.go
+++ b/auxiliary.go
@@ -2,10 +2,12 @@ package lua
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"syscall"
 )
 
 func functionName(l *State, d Debug) string {
@@ -568,8 +570,254 @@ func FileResult(l *State, err error, filename string) int {
 	} else {
 		l.PushString(err.Error())
 	}
-	l.PushInteger(0) // TODO map err to errno
+	errno, ok := fileErrorToErrno(err)
+	if !ok {
+		errno = 0
+	}
+	l.PushInteger(errno)
 	return 3
+}
+
+func fileErrorToErrno(err error) (errno int, ok bool) {
+	if errors.Is(err, io.ErrClosedPipe) {
+		errno, ok = int(int64(uintptr(syscall.EPIPE))), true
+	} else {
+		switch err.Error() {
+		case "EPERM":
+			errno, ok = int(int64(uintptr(syscall.EPERM))), true
+		case "ENOENT":
+			errno, ok = int(int64(uintptr(syscall.ENOENT))), true
+		case "ESRCH":
+			errno, ok = int(int64(uintptr(syscall.ESRCH))), true
+		case "EINTR":
+			errno, ok = int(int64(uintptr(syscall.EINTR))), true
+		case "EIO":
+			errno, ok = int(int64(uintptr(syscall.EIO))), true
+		case "ENXIO":
+			errno, ok = int(int64(uintptr(syscall.ENXIO))), true
+		case "E2BIG":
+			errno, ok = int(int64(uintptr(syscall.E2BIG))), true
+		case "ENOEXEC":
+			errno, ok = int(int64(uintptr(syscall.ENOEXEC))), true
+		case "EBADF":
+			errno, ok = int(int64(uintptr(syscall.EBADF))), true
+		case "ECHILD":
+			errno, ok = int(int64(uintptr(syscall.ECHILD))), true
+		case "EAGAIN":
+			errno, ok = int(int64(uintptr(syscall.EAGAIN))), true
+		case "ENOMEM":
+			errno, ok = int(int64(uintptr(syscall.ENOMEM))), true
+		case "EACCES":
+			errno, ok = int(int64(uintptr(syscall.EACCES))), true
+		case "EFAULT":
+			errno, ok = int(int64(uintptr(syscall.EFAULT))), true
+		case "EBUSY":
+			errno, ok = int(int64(uintptr(syscall.EBUSY))), true
+		case "EEXIST":
+			errno, ok = int(int64(uintptr(syscall.EEXIST))), true
+		case "EXDEV":
+			errno, ok = int(int64(uintptr(syscall.EXDEV))), true
+		case "ENODEV":
+			errno, ok = int(int64(uintptr(syscall.ENODEV))), true
+		case "ENOTDIR":
+			errno, ok = int(int64(uintptr(syscall.ENOTDIR))), true
+		case "EISDIR":
+			errno, ok = int(int64(uintptr(syscall.EISDIR))), true
+		case "EINVAL":
+			errno, ok = int(int64(uintptr(syscall.EINVAL))), true
+		case "ENFILE":
+			errno, ok = int(int64(uintptr(syscall.ENFILE))), true
+		case "EMFILE":
+			errno, ok = int(int64(uintptr(syscall.EMFILE))), true
+		case "ENOTTY":
+			errno, ok = int(int64(uintptr(syscall.ENOTTY))), true
+		case "EFBIG":
+			errno, ok = int(int64(uintptr(syscall.EFBIG))), true
+		case "ENOSPC":
+			errno, ok = int(int64(uintptr(syscall.ENOSPC))), true
+		case "ESPIPE":
+			errno, ok = int(int64(uintptr(syscall.ESPIPE))), true
+		case "EROFS":
+			errno, ok = int(int64(uintptr(syscall.EROFS))), true
+		case "EMLINK":
+			errno, ok = int(int64(uintptr(syscall.EMLINK))), true
+		case "EPIPE":
+			errno, ok = int(int64(uintptr(syscall.EPIPE))), true
+		case "ENAMETOOLONG":
+			errno, ok = int(int64(uintptr(syscall.ENAMETOOLONG))), true
+		case "ENOSYS":
+			errno, ok = int(int64(uintptr(syscall.ENOSYS))), true
+		case "EDQUOT":
+			errno, ok = int(int64(uintptr(syscall.EDQUOT))), true
+		case "EDOM":
+			errno, ok = int(int64(uintptr(syscall.EDOM))), true
+		case "ERANGE":
+			errno, ok = int(int64(uintptr(syscall.ERANGE))), true
+		case "EDEADLK":
+			errno, ok = int(int64(uintptr(syscall.EDEADLK))), true
+		case "ENOLCK":
+			errno, ok = int(int64(uintptr(syscall.ENOLCK))), true
+		case "ENOTEMPTY":
+			errno, ok = int(int64(uintptr(syscall.ENOTEMPTY))), true
+		case "ELOOP":
+			errno, ok = int(int64(uintptr(syscall.ELOOP))), true
+		case "ENOMSG":
+			errno, ok = int(int64(uintptr(syscall.ENOMSG))), true
+		case "EIDRM":
+			errno, ok = int(int64(uintptr(syscall.EIDRM))), true
+		case "ECHRNG":
+			errno, ok = int(int64(uintptr(syscall.ECHRNG))), true
+		case "EL2NSYNC":
+			errno, ok = int(int64(uintptr(syscall.EL2NSYNC))), true
+		case "EL3HLT":
+			errno, ok = int(int64(uintptr(syscall.EL3HLT))), true
+		case "EL3RST":
+			errno, ok = int(int64(uintptr(syscall.EL3RST))), true
+		case "ELNRNG":
+			errno, ok = int(int64(uintptr(syscall.ELNRNG))), true
+		case "EUNATCH":
+			errno, ok = int(int64(uintptr(syscall.EUNATCH))), true
+		case "ENOCSI":
+			errno, ok = int(int64(uintptr(syscall.ENOCSI))), true
+		case "EL2HLT":
+			errno, ok = int(int64(uintptr(syscall.EL2HLT))), true
+		case "EBADE":
+			errno, ok = int(int64(uintptr(syscall.EBADE))), true
+		case "EBADR":
+			errno, ok = int(int64(uintptr(syscall.EBADR))), true
+		case "EXFULL":
+			errno, ok = int(int64(uintptr(syscall.EXFULL))), true
+		case "ENOANO":
+			errno, ok = int(int64(uintptr(syscall.ENOANO))), true
+		case "EBADRQC":
+			errno, ok = int(int64(uintptr(syscall.EBADRQC))), true
+		case "EBADSLT":
+			errno, ok = int(int64(uintptr(syscall.EBADSLT))), true
+		case "EDEADLOCK":
+			errno, ok = int(int64(uintptr(syscall.EDEADLOCK))), true
+		case "EBFONT":
+			errno, ok = int(int64(uintptr(syscall.EBFONT))), true
+		case "ENOSTR":
+			errno, ok = int(int64(uintptr(syscall.ENOSTR))), true
+		case "ENODATA":
+			errno, ok = int(int64(uintptr(syscall.ENODATA))), true
+		case "ETIME":
+			errno, ok = int(int64(uintptr(syscall.ETIME))), true
+		case "ENOSR":
+			errno, ok = int(int64(uintptr(syscall.ENOSR))), true
+		case "ENONET":
+			errno, ok = int(int64(uintptr(syscall.ENONET))), true
+		case "ENOPKG":
+			errno, ok = int(int64(uintptr(syscall.ENOPKG))), true
+		case "EREMOTE":
+			errno, ok = int(int64(uintptr(syscall.EREMOTE))), true
+		case "ENOLINK":
+			errno, ok = int(int64(uintptr(syscall.ENOLINK))), true
+		case "EADV":
+			errno, ok = int(int64(uintptr(syscall.EADV))), true
+		case "ESRMNT":
+			errno, ok = int(int64(uintptr(syscall.ESRMNT))), true
+		case "ECOMM":
+			errno, ok = int(int64(uintptr(syscall.ECOMM))), true
+		case "EPROTO":
+			errno, ok = int(int64(uintptr(syscall.EPROTO))), true
+		case "EMULTIHOP":
+			errno, ok = int(int64(uintptr(syscall.EMULTIHOP))), true
+		case "EDOTDOT":
+			errno, ok = int(int64(uintptr(syscall.EDOTDOT))), true
+		case "EBADMSG":
+			errno, ok = int(int64(uintptr(syscall.EBADMSG))), true
+		case "EOVERFLOW":
+			errno, ok = int(int64(uintptr(syscall.EOVERFLOW))), true
+		case "ENOTUNIQ":
+			errno, ok = int(int64(uintptr(syscall.ENOTUNIQ))), true
+		case "EBADFD":
+			errno, ok = int(int64(uintptr(syscall.EBADFD))), true
+		case "EREMCHG":
+			errno, ok = int(int64(uintptr(syscall.EREMCHG))), true
+		case "ELIBACC":
+			errno, ok = int(int64(uintptr(syscall.ELIBACC))), true
+		case "ELIBBAD":
+			errno, ok = int(int64(uintptr(syscall.ELIBBAD))), true
+		case "ELIBSCN":
+			errno, ok = int(int64(uintptr(syscall.ELIBSCN))), true
+		case "ELIBMAX":
+			errno, ok = int(int64(uintptr(syscall.ELIBMAX))), true
+		case "ELIBEXEC":
+			errno, ok = int(int64(uintptr(syscall.ELIBEXEC))), true
+		case "EILSEQ":
+			errno, ok = int(int64(uintptr(syscall.EILSEQ))), true
+		case "EUSERS":
+			errno, ok = int(int64(uintptr(syscall.EUSERS))), true
+		case "ENOTSOCK":
+			errno, ok = int(int64(uintptr(syscall.ENOTSOCK))), true
+		case "EDESTADDRREQ":
+			errno, ok = int(int64(uintptr(syscall.EDESTADDRREQ))), true
+		case "EMSGSIZE":
+			errno, ok = int(int64(uintptr(syscall.EMSGSIZE))), true
+		case "EPROTOTYPE":
+			errno, ok = int(int64(uintptr(syscall.EPROTOTYPE))), true
+		case "ENOPROTOOPT":
+			errno, ok = int(int64(uintptr(syscall.ENOPROTOOPT))), true
+		case "EPROTONOSUPPORT":
+			errno, ok = int(int64(uintptr(syscall.EPROTONOSUPPORT))), true
+		case "ESOCKTNOSUPPORT":
+			errno, ok = int(int64(uintptr(syscall.ESOCKTNOSUPPORT))), true
+		case "EOPNOTSUPP":
+			errno, ok = int(int64(uintptr(syscall.EOPNOTSUPP))), true
+		case "EPFNOSUPPORT":
+			errno, ok = int(int64(uintptr(syscall.EPFNOSUPPORT))), true
+		case "EAFNOSUPPORT":
+			errno, ok = int(int64(uintptr(syscall.EAFNOSUPPORT))), true
+		case "EADDRINUSE":
+			errno, ok = int(int64(uintptr(syscall.EADDRINUSE))), true
+		case "EADDRNOTAVAIL":
+			errno, ok = int(int64(uintptr(syscall.EADDRNOTAVAIL))), true
+		case "ENETDOWN":
+			errno, ok = int(int64(uintptr(syscall.ENETDOWN))), true
+		case "ENETUNREACH":
+			errno, ok = int(int64(uintptr(syscall.ENETUNREACH))), true
+		case "ENETRESET":
+			errno, ok = int(int64(uintptr(syscall.ENETRESET))), true
+		case "ECONNABORTED":
+			errno, ok = int(int64(uintptr(syscall.ECONNABORTED))), true
+		case "ECONNRESET":
+			errno, ok = int(int64(uintptr(syscall.ECONNRESET))), true
+		case "ENOBUFS":
+			errno, ok = int(int64(uintptr(syscall.ENOBUFS))), true
+		case "EISCONN":
+			errno, ok = int(int64(uintptr(syscall.EISCONN))), true
+		case "ENOTCONN":
+			errno, ok = int(int64(uintptr(syscall.ENOTCONN))), true
+		case "ESHUTDOWN":
+			errno, ok = int(int64(uintptr(syscall.ESHUTDOWN))), true
+		case "ETOOMANYREFS":
+			errno, ok = int(int64(uintptr(syscall.ETOOMANYREFS))), true
+		case "ETIMEDOUT":
+			errno, ok = int(int64(uintptr(syscall.ETIMEDOUT))), true
+		case "ECONNREFUSED":
+			errno, ok = int(int64(uintptr(syscall.ECONNREFUSED))), true
+		case "EHOSTDOWN":
+			errno, ok = int(int64(uintptr(syscall.EHOSTDOWN))), true
+		case "EHOSTUNREACH":
+			errno, ok = int(int64(uintptr(syscall.EHOSTUNREACH))), true
+		case "EALREADY":
+			errno, ok = int(int64(uintptr(syscall.EALREADY))), true
+		case "EINPROGRESS":
+			errno, ok = int(int64(uintptr(syscall.EINPROGRESS))), true
+		case "ESTALE":
+			errno, ok = int(int64(uintptr(syscall.ESTALE))), true
+		case "ENOTSUP":
+			errno, ok = int(int64(uintptr(syscall.ENOTSUP))), true
+		case "ENOMEDIUM":
+			errno, ok = int(int64(uintptr(syscall.ENOMEDIUM))), true
+		case "ECANCELED":
+			errno, ok = int(int64(uintptr(syscall.ECANCELED))), true
+		case "EWOULDBLOCK":
+			errno, ok = int(int64(uintptr(syscall.EWOULDBLOCK))), true
+		}
+	}
+	return
 }
 
 // DoFile loads and runs the given file.

--- a/debug.go
+++ b/debug.go
@@ -482,8 +482,7 @@ var debugLibrary = []RegistryFunction{
 		} else {
 			hookTable(l)
 			l1.PushThread()
-			//			XMove(l1, l, 1)
-			panic("XMove not implemented yet")
+			xMove(l1, l, 1)
 			l.RawGet(-2)
 			l.Remove(-2)
 		}
@@ -543,8 +542,7 @@ var debugLibrary = []RegistryFunction{
 			l.SetMetaTable(-2)
 		}
 		l1.PushThread()
-		//	 	XMove(l1, l, 1)
-		panic("XMove not yet implemented")
+		xMove(l1, l, 1)
 		l.PushValue(i + 1)
 		l.RawSet(-3)
 		SetDebugHook(l1, hook, mask, count)

--- a/lua.go
+++ b/lua.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"strings"
+	"unsafe"
 )
 
 // MultipleReturns is the argument for argCount or resultCount in ProtectedCall and Call.
@@ -283,7 +284,8 @@ func (g *globalState) metaTable(o value) *table {
 		t = TypeNil
 	case bool:
 		t = TypeBoolean
-	// TODO TypeLightUserData
+	case unsafe.Pointer:
+		t = TypeLightUserData
 	case float64:
 		t = TypeNumber
 	case string:
@@ -659,8 +661,8 @@ func (l *State) valueToType(v value) Type {
 		return TypeNil
 	case bool:
 		return TypeBoolean
-	// case lightUserData:
-	// 	return TypeLightUserData
+	case unsafe.Pointer:
+		return TypeLightUserData
 	case float64:
 		return TypeNumber
 	case string:

--- a/lua.go
+++ b/lua.go
@@ -516,17 +516,17 @@ var none value = &struct{}{}
 func (l *State) indexToValue(index int) value {
 	switch {
 	case index > 0:
-		// TODO apiCheck(index <= callInfo.top_-(callInfo.function+1), "unacceptable index")
-		// if i := callInfo.function + index; i < l.top {
-		// 	return l.stack[i]
-		// }
-		// return none
+		if apiCheck && index < l.callInfo.top-(l.callInfo.function+1) {
+			panic("unacceptable index")
+		}
 		if l.callInfo.function+index >= l.top {
 			return none
 		}
 		return l.stack[l.callInfo.function:l.top][index]
 	case index > RegistryIndex: // negative index
-		// TODO apiCheck(index != 0 && -index <= l.top-(callInfo.function+1), "invalid index")
+		if apiCheck && index != 0 && -index <= l.top-(l.callInfo.function+1) {
+			panic("invalid index")
+		}
 		return l.stack[l.top+index]
 	case index == RegistryIndex:
 		return l.global.registry

--- a/vm.go
+++ b/vm.go
@@ -182,9 +182,10 @@ func (l *State) concat(total int) {
 	l.assert(total >= 2)
 	for total > 1 {
 		n := 2 // # of elements handled in this pass (at least 2)
-		s2, ok := t(2).(string)
-		if !ok {
-			_, ok = t(2).(float64)
+		var ok bool
+		switch t(2).(type) {
+		case string, float64:
+			ok = true
 		}
 		if !ok {
 			concatTagMethod()
@@ -193,7 +194,7 @@ func (l *State) concat(total int) {
 		} else if len(s1) == 0 {
 			v, _ := l.toString(l.top - 2)
 			put(2, v)
-		} else if s2, ok = t(2).(string); ok && len(s2) == 0 {
+		} else if s2, ok := t(2).(string); ok && len(s2) == 0 {
 			put(2, t(1))
 		} else {
 			// at least 2 non-empty strings; scarf as many as possible


### PR DESCRIPTION
## Added
- XMove support within debug hook calls
- Conversion of FileResult error responses to errno (still not correct, but better than nothing)
  - Go doesn't provide a mechanism for easily enumerating error codes from file IO, even though the error codes were what originally spawned the error interface we do have access to. Eventually, I suspect we'll get a mechanism for yo-yoing between these values, but for now, we have to do it the hard way.
- Support for LightUserdata typed data as `unsafe.Pointer`
- Add apiChecks to the `indexToValue` call

## Fixed and Changed
- Changed a few type-sizing algorithms in the Undump code to use the math and math/bits functions instead.
- Changed the `concat()` function in the VM to be a little more straightforward with its type testing.
